### PR TITLE
Fix an issue with cell refs overflow for messages with state init

### DIFF
--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -62,7 +62,8 @@ export function storeMessage(message: Message, opts?: { forceRef?: boolean }) {
         if (opts && opts.forceRef) {
             needRef = true;
         } else {
-            if (builder.availableBits - 1 /* At least on byte for body */ >= message.body.bits.length) {
+            if (builder.availableBits - 1 /* At least on byte for body */ >= message.body.bits.length &&
+                  builder.refs + message.body.refs.length <= 4) {
                 needRef = false;
             } else {
                 needRef = true;


### PR DESCRIPTION
It seems Messages.ts::storeMessage has a bug with parsing messages with state init and body with 3+ refs. [Here is a small test cases](https://gist.github.com/shuva10v/8a3b5f859458d42f296055c75a26ab26) (it is based on sandbox library) with the issue. It looks like legit from the TVM point of view, but it does not work with upstream code (and it works with ``forceRef=true`` mode)