### PR TITLE
fix: toNano

### DIFF
--- a/src/utils/convert.spec.ts
+++ b/src/utils/convert.spec.ts
@@ -8,22 +8,46 @@
 
 import { fromNano, toNano } from "./convert";
 
-const cases: { nano: string, real: string }[] = [
+const stringCases: { nano: string, real: string }[] = [
     { real: '1', nano: '1000000000' },
     { real: '10', nano: '10000000000' },
     { real: '0.1', nano: '100000000' },
-    { real: '0.33', nano: '330000000' }
+    { real: '0.33', nano: '330000000' },
+    { real: '0.000000001', nano: '1' },
+    { real: '10.000000001', nano: '10000000001' },
+    { real: '1000000.000000001', nano: '1000000000000001' },
+    { real: '100000000000', nano: '100000000000000000000' },
+];
+
+const numberCases: { nano: string, real: number }[] = [
+    { real: 1, nano: '1000000000' },
+    { real: 10, nano: '10000000000' },
+    { real: 0.1, nano: '100000000' },
+    { real: 0.33, nano: '330000000' },
+    { real: 0.000000001, nano: '1' },
+    { real: 10.000000001, nano: '10000000001' },
+    { real: 1000000.000000001, nano: '1000000000000001' },
+    { real: 100000000000, nano: '100000000000000000000' },
 ];
 
 describe('convert', () => {
-    it('should convert toNano', () => {
-        for (let r of cases) {
+    it('should throw an error due to insufficient precision of number', () => {
+        expect(() => toNano(10000000.000000001)).toThrow();
+    });
+    it('should convert numbers toNano', () => {
+        for (let r of numberCases) {
+            let c = toNano(r.real);
+            expect(c).toBe(BigInt(r.nano));
+        }
+    });
+    it('should convert strings toNano', () => {
+        for (let r of stringCases) {
             let c = toNano(r.real);
             expect(c).toBe(BigInt(r.nano));
         }
     });
     it('should convert fromNano', () => {
-        for (let r of cases) {
+        for (let r of stringCases) {
             let c = fromNano(r.nano);
             expect(c).toEqual(r.real);
         }

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -12,7 +12,13 @@ export function toNano(src: number | string | bigint): bigint {
         return src * 1000000000n;
     } else {
         if (typeof src === 'number') {
-            src = String(src);
+            if (Math.log10(src) <= 6) {
+                src = src.toLocaleString('en', { minimumFractionDigits: 9, useGrouping: false });
+            } else if (src - Math.trunc(src) === 0) {
+                src = src.toLocaleString('en', { maximumFractionDigits: 0, useGrouping: false });
+            } else {
+                throw Error('Not enough precision for a number value. Use string value instead');
+            }
         }
 
         // Check sign

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -10,9 +10,10 @@ export function toNano(src: number | string | bigint): bigint {
 
     if (typeof src === 'bigint') {
         return src * 1000000000n;
-    } else if (typeof src === 'number') {
-        return BigInt(src) * 1000000000n;
     } else {
+        if (typeof src === 'number') {
+            src = String(src);
+        }
 
         // Check sign
         let neg = false;


### PR DESCRIPTION
Using small numbers (< 0) in the toNano function. Just convert it to string before parsing