### PR TITLE
Fix Cell Hash Issues in Block BoC Formation

### DIFF
--- a/src/boc/cell/descriptor.ts
+++ b/src/boc/cell/descriptor.ts
@@ -20,7 +20,7 @@ export function getBitsDescriptor(bits: BitString) {
     return Math.ceil(len / 8) + Math.floor(len / 8);
 }
 
-export function getRepr(bits: BitString, refs: Cell[], level: number, type: CellType) {
+export function getRepr(originalBits: BitString, bits: BitString, refs: Cell[], level: number, type: CellType) {
 
     // Allocate
     const bitsLen = Math.ceil(bits.length / 8);
@@ -29,7 +29,7 @@ export function getRepr(bits: BitString, refs: Cell[], level: number, type: Cell
     // Write descriptors
     let reprCursor = 0;
     repr[reprCursor++] = getRefsDescriptor(refs, level, type);
-    repr[reprCursor++] = getBitsDescriptor(bits);
+    repr[reprCursor++] = getBitsDescriptor(originalBits);
 
     // Write bits
     bitsToPaddedBuffer(bits).copy(repr, reprCursor);

--- a/src/boc/cell/wonderCalculator.ts
+++ b/src/boc/cell/wonderCalculator.ts
@@ -129,7 +129,7 @@ export function wonderCalculator(type: CellType, bits: BitString, refs: Cell[]):
         // Hash
         //
 
-        let repr = getRepr(currentBits, refs, levelI, type);
+        let repr = getRepr(bits, currentBits, refs, levelI, type);
         let hash = sha256_sync(repr);
 
         //


### PR DESCRIPTION
### Problems

- In some cases, a block's BoC could not be formed (`Cell.fromBoc`) — the calculated `hash` of `exotic` cells did not match the hash recorded inside the cell.
- In some cases, the `rootHash` of a block (`rootCell.hash(0)`) obtained using `Cell.fromBoc` did not match the `rootHash` obtained from _tonCenter_ for the same block.

### Solutions

- In the `getRepr` function, when calling `getBitsDescriptor`, the bits of that cell are now always used (prior to the fix, a hash could be passed in, breaking the reading)
- In _serialization.ts_ `readCell()` function, added reading (`reader.skip`) of hashes and depths recorded inside the cell.

Block hashes are now calculated correctly